### PR TITLE
[feature] adicionar navegação interna e estados do módulo de relatórios

### DIFF
--- a/front-end/src/pages/Reports.tsx
+++ b/front-end/src/pages/Reports.tsx
@@ -33,6 +33,7 @@ export default function Reports() {
       onVehicleFilterChange={data.setVehicleFilter}
       companyFilter={data.companyFilter}
       onCompanyFilterChange={data.setCompanyFilter}
+      onResetFilters={data.resetFilters}
       vehicles={data.vehicles}
       companies={data.companies}
       loading={data.loading}

--- a/front-end/src/pages/reports/ReportsFinancial.tsx
+++ b/front-end/src/pages/reports/ReportsFinancial.tsx
@@ -1,13 +1,30 @@
 import React from 'react';
 import { FileText, Route, Wallet } from 'lucide-react';
 import { useReportsData } from './useReportsData';
-import { EmptyText, ExecutiveRow, MetricBox, Panel, ProgressRow } from './ReportsSharedComponents';
+import { EmptyText, ExecutiveRow, MetricBox, Panel, ProgressRow, ReportsEmptyState } from './ReportsSharedComponents';
 
 type ReportsFinancialProps = {
   data: ReturnType<typeof useReportsData>;
 };
 
 export default function ReportsFinancial({ data }: ReportsFinancialProps) {
+  const hasFinancialData =
+    data.filteredExpenses.length > 0 ||
+    data.activePayables.length > 0 ||
+    data.contractRevenue > 0 ||
+    data.freightRevenue > 0 ||
+    data.receivedRevenue > 0 ||
+    data.openRevenue > 0;
+
+  if (!hasFinancialData) {
+    return (
+      <ReportsEmptyState
+        title="Nenhuma movimentacao financeira encontrada"
+        description="Ajuste os filtros ou registre contas a receber, custos operacionais e contas a pagar para visualizar a leitura financeira deste periodo."
+      />
+    );
+  }
+
   return (
     <div className="space-y-8">
       <section className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">

--- a/front-end/src/pages/reports/ReportsLayout.tsx
+++ b/front-end/src/pages/reports/ReportsLayout.tsx
@@ -104,6 +104,7 @@ interface ReportsLayoutProps {
   onVehicleFilterChange: (value: string) => void;
   companyFilter: string;
   onCompanyFilterChange: (value: string) => void;
+  onResetFilters: () => void;
   vehicles: Vehicle[];
   companies: Company[];
   loading: boolean;
@@ -125,6 +126,7 @@ export default function ReportsLayout(props: ReportsLayoutProps) {
     onVehicleFilterChange,
     companyFilter,
     onCompanyFilterChange,
+    onResetFilters,
     vehicles,
     companies,
     loading,
@@ -133,6 +135,8 @@ export default function ReportsLayout(props: ReportsLayoutProps) {
     onRefresh,
     children,
   } = props;
+
+  const activeTabMeta = REPORT_TABS.find((tab) => tab.id === activeTab);
 
   if (loading) {
     return (
@@ -170,20 +174,31 @@ export default function ReportsLayout(props: ReportsLayoutProps) {
           </div>
         )}
 
-        <div className="flex flex-col xl:flex-row gap-4">
-          {REPORT_TABS.map((tab) => (
-            <button
-              key={tab.id}
-              onClick={() => onTabChange(tab.id)}
-              className={cn(
-                'flex-1 rounded-3xl border p-5 text-left transition-all',
-                activeTab === tab.id ? 'bg-primary text-on-primary border-primary shadow-lg shadow-primary/20' : 'bg-surface-container-lowest border-outline-variant hover:border-primary/40'
-              )}
-            >
-              <p className="font-black text-lg">{tab.label}</p>
-              <p className={cn('text-sm mt-1', activeTab === tab.id ? 'text-on-primary/80' : 'text-on-surface-variant')}>{tab.description}</p>
-            </button>
-          ))}
+        <div className="rounded-3xl border border-outline-variant bg-surface-container-lowest p-4">
+          <div className="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+            <div>
+              <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-primary">Visao ativa</p>
+              <p className="mt-2 text-xl font-black text-on-surface">{activeTabMeta?.label}</p>
+              <p className="mt-1 text-sm text-on-surface-variant">{activeTabMeta?.description}</p>
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              {REPORT_TABS.map((tab) => (
+                <button
+                  key={tab.id}
+                  onClick={() => onTabChange(tab.id)}
+                  className={cn(
+                    'rounded-full border px-4 py-2 text-sm font-bold transition-all',
+                    activeTab === tab.id
+                      ? 'border-primary bg-primary text-on-primary shadow-lg shadow-primary/15'
+                      : 'border-outline-variant bg-surface text-on-surface-variant hover:border-primary/40 hover:text-on-surface'
+                  )}
+                >
+                  {tab.label.replace('Relatorio ', '')}
+                </button>
+              ))}
+            </div>
+          </div>
         </div>
       </header>
 
@@ -210,6 +225,16 @@ export default function ReportsLayout(props: ReportsLayoutProps) {
           </select>
         </div>
       </section>
+
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={onResetFilters}
+          className="rounded-full border border-outline-variant bg-surface-container-lowest px-4 py-2 text-sm font-bold text-on-surface-variant transition hover:border-primary/40 hover:text-on-surface"
+        >
+          Limpar filtros
+        </button>
+      </div>
 
       {children}
     </div>

--- a/front-end/src/pages/reports/ReportsManagerial.tsx
+++ b/front-end/src/pages/reports/ReportsManagerial.tsx
@@ -1,13 +1,22 @@
 import React from 'react';
 import { Building2, CheckCircle, FileText, Wallet } from 'lucide-react';
 import { useReportsData } from './useReportsData';
-import { EmptyText, ExecutiveRow, MetricBox, Panel } from './ReportsSharedComponents';
+import { EmptyText, ExecutiveRow, MetricBox, Panel, ReportsEmptyState } from './ReportsSharedComponents';
 
 type ReportsManagerialProps = {
   data: ReturnType<typeof useReportsData>;
 };
 
 export default function ReportsManagerial({ data }: ReportsManagerialProps) {
+  if (data.filteredContracts.length === 0 && data.companyPerformance.length === 0) {
+    return (
+      <ReportsEmptyState
+        title="Ainda nao ha dados gerenciais suficientes"
+        description="Cadastre contratos e relacione empresas ao periodo filtrado para destravar esta visao consolidada da transportadora."
+      />
+    );
+  }
+
   return (
     <div className="space-y-8">
       <section className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">

--- a/front-end/src/pages/reports/ReportsOperational.tsx
+++ b/front-end/src/pages/reports/ReportsOperational.tsx
@@ -1,13 +1,22 @@
 import React from 'react';
 import { Filter, Route, Truck } from 'lucide-react';
 import { useReportsData } from './useReportsData';
-import { EmptyText, MapMarkerIcon, MetricBox, Panel } from './ReportsSharedComponents';
+import { EmptyText, MapMarkerIcon, MetricBox, Panel, ReportsEmptyState } from './ReportsSharedComponents';
 
 type ReportsOperationalProps = {
   data: ReturnType<typeof useReportsData>;
 };
 
 export default function ReportsOperational({ data }: ReportsOperationalProps) {
+  if (data.filteredFreights.length === 0) {
+    return (
+      <ReportsEmptyState
+        title="Nenhuma viagem encontrada no periodo"
+        description="Quando houver fretes dentro do intervalo filtrado, esta visao mostrara uso da frota, rotas mais frequentes e indicadores operacionais."
+      />
+    );
+  }
+
   return (
     <div className="space-y-8">
       <section className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">

--- a/front-end/src/pages/reports/ReportsSharedComponents.tsx
+++ b/front-end/src/pages/reports/ReportsSharedComponents.tsx
@@ -58,3 +58,18 @@ export function MapMarkerIcon(props: React.ComponentProps<'svg'>) {
     </svg>
   );
 }
+
+export function ReportsEmptyState({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <section className="rounded-3xl border border-dashed border-outline-variant bg-surface-container-lowest px-8 py-12 text-center">
+      <p className="text-xl font-black text-on-surface">{title}</p>
+      <p className="mx-auto mt-3 max-w-2xl text-sm leading-relaxed text-on-surface-variant">{description}</p>
+    </section>
+  );
+}

--- a/front-end/src/pages/reports/useReportsData.ts
+++ b/front-end/src/pages/reports/useReportsData.ts
@@ -4,6 +4,7 @@ import { Company, Contract, Expense, Freight, Payable, Revenue, Vehicle } from '
 import { getCurrentMonthRange, parseLocalDate, ReportTab, toDateInputValue } from './reports.shared';
 
 export function useReportsData() {
+  const defaultRange = getCurrentMonthRange();
   const [expenses, setExpenses] = useState<Expense[]>([]);
   const [payables, setPayables] = useState<Payable[]>([]);
   const [vehicles, setVehicles] = useState<Vehicle[]>([]);
@@ -15,14 +16,8 @@ export function useReportsData() {
   const [refreshing, setRefreshing] = useState(false);
   const [loadError, setLoadError] = useState('');
   const [activeTab, setActiveTab] = useState<ReportTab>('financial');
-  const [startDate, setStartDate] = useState(() => {
-    const { start } = getCurrentMonthRange();
-    return toDateInputValue(start);
-  });
-  const [endDate, setEndDate] = useState(() => {
-    const { end } = getCurrentMonthRange();
-    return toDateInputValue(end);
-  });
+  const [startDate, setStartDate] = useState(() => toDateInputValue(defaultRange.start));
+  const [endDate, setEndDate] = useState(() => toDateInputValue(defaultRange.end));
   const [vehicleFilter, setVehicleFilter] = useState('all');
   const [companyFilter, setCompanyFilter] = useState('all');
 
@@ -197,9 +192,16 @@ export function useReportsData() {
     }).filter((item) => item.contracts > 0).sort((a, b) => b.monthlyRevenue - a.monthlyRevenue)
   ), [companies, filteredContracts]);
 
+  const resetFilters = () => {
+    setStartDate(toDateInputValue(defaultRange.start));
+    setEndDate(toDateInputValue(defaultRange.end));
+    setVehicleFilter('all');
+    setCompanyFilter('all');
+  };
+
   return {
     activeTab, setActiveTab, startDate, setStartDate, endDate, setEndDate, vehicleFilter, setVehicleFilter, companyFilter, setCompanyFilter,
-    loading, refreshing, loadError, loadReports, vehicles, companies, contracts,
+    loading, refreshing, loadError, loadReports, resetFilters, vehicles, companies, contracts,
     filteredExpenses, filteredFreights, totalOperationalCosts, activePayables, paidPayables, openPayables, overduePayables,
     contractRevenue, freightRevenue, receivedRevenue, openRevenue, projectedRevenue, netResult, activeVehicles, maintenanceAlerts,
     activeContracts, activeCompanies, routeRanking, vehiclePerformance, companyPerformance,


### PR DESCRIPTION
## Objetivo
Transformar relatórios em um módulo navegável e com estados de interface mais completos.

## Escopo
- adicionar navegação interna por visão
- adicionar ação de limpar filtros
- melhorar empty states e contexto da visão ativa
- fortalecer a experiência do módulo para uso real

## Como validar
- navegar entre financeiro, operacional e gerencial
- testar limpeza de filtros
- validar estados vazios e atualização de contexto
