### PR TITLE
[test] cobrir fluxo e renderização do módulo de relatórios

### DIFF
--- a/back-end/__tests__/modules/reports-module-coverage.test.ts
+++ b/back-end/__tests__/modules/reports-module-coverage.test.ts
@@ -51,6 +51,7 @@ test('hook compartilhado de relatorios centraliza filtros estados e agregacoes',
   assert.match(reportsDataSource, /const vehiclePerformance = useMemo/);
   assert.match(reportsDataSource, /const companyPerformance = useMemo/);
   assert.match(reportsDataSource, /const resetFilters = \(\) =>/);
+  assert.match(reportsDataSource, /filteredExpenses, filteredFreights, filteredContracts, totalOperationalCosts/);
   assert.match(reportsDataSource, /setVehicleFilter\('all'\)/);
   assert.match(reportsDataSource, /setCompanyFilter\('all'\)/);
 });

--- a/front-end/src/pages/reports/useReportsData.ts
+++ b/front-end/src/pages/reports/useReportsData.ts
@@ -202,7 +202,7 @@ export function useReportsData() {
   return {
     activeTab, setActiveTab, startDate, setStartDate, endDate, setEndDate, vehicleFilter, setVehicleFilter, companyFilter, setCompanyFilter,
     loading, refreshing, loadError, loadReports, resetFilters, vehicles, companies, contracts,
-    filteredExpenses, filteredFreights, totalOperationalCosts, activePayables, paidPayables, openPayables, overduePayables,
+    filteredExpenses, filteredFreights, filteredContracts, totalOperationalCosts, activePayables, paidPayables, openPayables, overduePayables,
     contractRevenue, freightRevenue, receivedRevenue, openRevenue, projectedRevenue, netResult, activeVehicles, maintenanceAlerts,
     activeContracts, activeCompanies, routeRanking, vehiclePerformance, companyPerformance,
   };


### PR DESCRIPTION
## Objetivo
Adicionar cobertura de teste para a refatoração do módulo de relatórios.

## Escopo
- validar o shell do módulo
- validar layout compartilhado
- validar hook central de dados e filtros
- validar visões financeira, operacional e gerencial
- proteger o ajuste da visão gerencial com contratos filtrados

## Como validar
- executar `npm run test`
- executar `npm run build`
- confirmar que a suíte cobre o novo contrato do módulo
