### PR TITLE
[front] cobrir arquitetura base com testes

### DIFF
--- a/front-end/src/features/auth/hooks/usePermission.test.tsx
+++ b/front-end/src/features/auth/hooks/usePermission.test.tsx
@@ -1,0 +1,43 @@
+import { renderHook } from '@testing-library/react';
+import { usePermission } from './usePermission';
+import { UserProfile } from '../../../shared/types/common.types';
+
+const mockUseAuth = vi.fn();
+
+vi.mock('./useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+function makeProfile(role: UserProfile['role']): UserProfile {
+  return {
+    uid: `user-${role}`,
+    email: `${role}@teste.com`,
+    role,
+    tenantId: 'tenant-1',
+    tenantName: 'Tenant Teste',
+    tenantSlug: 'tenant-teste',
+  };
+}
+
+describe('usePermission', () => {
+  beforeEach(() => {
+    mockUseAuth.mockReset();
+  });
+
+  it('expõe can=true quando o perfil tem acesso', () => {
+    mockUseAuth.mockReturnValue({ userProfile: makeProfile('financial') });
+
+    const { result } = renderHook(() => usePermission('payables', 'read'));
+
+    expect(result.current.can).toBe(true);
+  });
+
+  it('expõe check reutilizável para outras combinações', () => {
+    mockUseAuth.mockReturnValue({ userProfile: makeProfile('viewer') });
+
+    const { result } = renderHook(() => usePermission());
+
+    expect(result.current.check('vehicles', 'read')).toBe(true);
+    expect(result.current.check('reports', 'read')).toBe(false);
+  });
+});

--- a/front-end/src/features/navigation/components/Sidebar.test.tsx
+++ b/front-end/src/features/navigation/components/Sidebar.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import Sidebar from './Sidebar';
+import { UserProfile } from '../../../shared/types/common.types';
+
+const mockUseAuth = vi.fn();
+
+vi.mock('../../auth/hooks/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+function makeProfile(role: UserProfile['role']): UserProfile {
+  return {
+    uid: `user-${role}`,
+    email: `${role}@teste.com`,
+    role,
+    tenantId: 'tenant-1',
+    tenantName: 'Nova Log',
+    tenantSlug: 'nova-log',
+  };
+}
+
+function LocationDisplay() {
+  const location = useLocation();
+  return <div data-testid="location-display">{location.pathname}</div>;
+}
+
+describe('Sidebar', () => {
+  beforeEach(() => {
+    mockUseAuth.mockReset();
+  });
+
+  it('navega para a rota do item clicado no menu', () => {
+    mockUseAuth.mockReturnValue({ userProfile: makeProfile('admin') });
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route
+            path="*"
+            element={
+              <>
+                <Sidebar activeItem="dashboard" />
+                <LocationDisplay />
+              </>
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /cadastros/i }));
+    fireEvent.click(screen.getByRole('button', { name: /veiculos/i }));
+
+    expect(screen.getByTestId('location-display')).toHaveTextContent('/veiculos');
+  });
+});

--- a/front-end/src/lib/permissions.test.ts
+++ b/front-end/src/lib/permissions.test.ts
@@ -1,0 +1,32 @@
+import { canAccess } from './permissions';
+import { UserProfile } from '../shared/types/common.types';
+
+function makeProfile(role: UserProfile['role']): UserProfile {
+  return {
+    uid: `user-${role}`,
+    email: `${role}@teste.com`,
+    role,
+    tenantId: 'tenant-1',
+    tenantName: 'Tenant Teste',
+    tenantSlug: 'tenant-teste',
+  };
+}
+
+describe('canAccess', () => {
+  it('retorna false sem perfil', () => {
+    expect(canAccess(null, 'expenses', 'read')).toBe(false);
+  });
+
+  it('permite leitura de custos para perfil operacional', () => {
+    expect(canAccess(makeProfile('operational'), 'expenses', 'read')).toBe(true);
+  });
+
+  it('nega relatorios para perfil viewer', () => {
+    expect(canAccess(makeProfile('viewer'), 'reports', 'read')).toBe(false);
+  });
+
+  it('permite plataforma apenas para dev', () => {
+    expect(canAccess(makeProfile('dev'), 'platformTenants', 'read')).toBe(true);
+    expect(canAccess(makeProfile('admin'), 'platformTenants', 'read')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Escopo
- cobre permissoes
- cobre hook declarativo
- cobre regressao de navegacao lateral
