### PR TITLE
[front] recuperar permissões declarativas na main

### DIFF
--- a/front-end/src/features/auth/components/Can.tsx
+++ b/front-end/src/features/auth/components/Can.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { type Action, type Section } from '../../../lib/permissions';
+import { usePermission } from '../hooks/usePermission';
+
+interface CanProps {
+  section: Section;
+  action: Action;
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+}
+
+export default function Can({ section, action, children, fallback = null }: CanProps) {
+  const { can } = usePermission(section, action);
+  return can ? <>{children}</> : <>{fallback}</>;
+}

--- a/front-end/src/features/auth/components/Guard.tsx
+++ b/front-end/src/features/auth/components/Guard.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { type Action, type Section } from '../../../lib/permissions';
+import { usePermission } from '../hooks/usePermission';
+
+interface GuardProps {
+  section: Section;
+  action: Action;
+  children: React.ReactNode;
+  redirectTo?: string;
+}
+
+export default function Guard({ section, action, children, redirectTo = '/' }: GuardProps) {
+  const { can } = usePermission(section, action);
+  if (!can) return <Navigate to={redirectTo} replace />;
+  return <>{children}</>;
+}

--- a/front-end/src/features/auth/hooks/usePermission.ts
+++ b/front-end/src/features/auth/hooks/usePermission.ts
@@ -1,0 +1,22 @@
+import { useCallback, useMemo } from 'react';
+import { canAccess, type Action, type Section } from '../../../lib/permissions';
+import { useAuth } from './useAuth';
+
+export function usePermission(section?: Section, action?: Action) {
+  const { userProfile } = useAuth();
+
+  const can = useMemo(() => {
+    if (!section || !action) return false;
+    return canAccess(userProfile, section, action);
+  }, [action, section, userProfile]);
+
+  const check = useCallback((targetSection: Section, targetAction: Action) => {
+    return canAccess(userProfile, targetSection, targetAction);
+  }, [userProfile]);
+
+  return {
+    can,
+    check,
+    userProfile,
+  };
+}

--- a/front-end/src/lib/permissions.ts
+++ b/front-end/src/lib/permissions.ts
@@ -1,8 +1,8 @@
-import { UserProfile } from '../types';
+import { UserProfile } from '../shared/types/common.types';
 
-type Role = UserProfile['role'];
-type Section = 'platformTenants' | 'tenantProfile' | 'revenues' | 'payables' | 'vehicles' | 'providers' | 'companies' | 'contracts' | 'freights' | 'expenses' | 'reports' | 'settings' | 'users';
-type Action = 'read' | 'create' | 'update' | 'delete';
+export type Role = UserProfile['role'];
+export type Section = 'platformTenants' | 'tenantProfile' | 'revenues' | 'payables' | 'vehicles' | 'providers' | 'companies' | 'contracts' | 'freights' | 'expenses' | 'reports' | 'settings' | 'users';
+export type Action = 'read' | 'create' | 'update' | 'delete';
 
 const sectionPermissions: Record<Section, Record<Action, Role[]>> = {
   platformTenants: {


### PR DESCRIPTION
Recupera na `main` a etapa de permissões declarativas que havia sido mergeada na base errada durante a pilha da refatoração do front.

Escopo:
- `usePermission`
- `Can`
- `Guard`
- integração inicial com permissões na navegação

Objetivo:
- recolocar a ordem correta da stack antes dos próximos merges.
