### PR TITLE
[front] recuperar shared ui na stack da main

### DIFF
--- a/front-end/src/components/CustomSelect.tsx
+++ b/front-end/src/components/CustomSelect.tsx
@@ -107,3 +107,5 @@ export default function CustomSelect({
     </div>
   );
 }
+
+export type { CustomSelectProps };

--- a/front-end/src/components/KpiCard.tsx
+++ b/front-end/src/components/KpiCard.tsx
@@ -218,3 +218,5 @@ export default function KpiCard({
     </article>
   );
 }
+
+export type { KpiCardProps };

--- a/front-end/src/components/MetricCard.tsx
+++ b/front-end/src/components/MetricCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { LucideIcon } from 'lucide-react';
-import KpiCard from './KpiCard';
+import { KpiCard } from '../shared/ui';
 
 interface MetricCardProps {
   label: string;

--- a/front-end/src/shared/ui/Alert.tsx
+++ b/front-end/src/shared/ui/Alert.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { AlertTriangle, CheckCircle2, Info, XCircle } from 'lucide-react';
+import { cn } from '../../lib/utils';
+
+type AlertTone = 'info' | 'success' | 'warning' | 'danger';
+
+interface AlertProps {
+  tone?: AlertTone;
+  title?: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+const toneMap = {
+  info: {
+    wrapper: 'border-primary/20 bg-primary/10 text-on-surface',
+    icon: Info,
+    iconClass: 'text-primary',
+  },
+  success: {
+    wrapper: 'border-primary/20 bg-primary-fixed/45 text-on-surface',
+    icon: CheckCircle2,
+    iconClass: 'text-primary',
+  },
+  warning: {
+    wrapper: 'border-secondary/20 bg-secondary-container/35 text-on-surface',
+    icon: AlertTriangle,
+    iconClass: 'text-secondary',
+  },
+  danger: {
+    wrapper: 'border-error/20 bg-error/10 text-on-surface',
+    icon: XCircle,
+    iconClass: 'text-error',
+  },
+} satisfies Record<AlertTone, { wrapper: string; icon: React.ElementType; iconClass: string }>;
+
+export default function Alert({ tone = 'info', title, children, className }: AlertProps) {
+  const config = toneMap[tone];
+  const Icon = config.icon;
+
+  return (
+    <div className={cn('rounded-2xl border p-4', config.wrapper, className)}>
+      <div className="flex gap-3">
+        <Icon className={cn('mt-0.5 h-4.5 w-4.5 shrink-0', config.iconClass)} />
+        <div className="min-w-0">
+          {title ? <p className="text-xs font-black uppercase tracking-[0.16em]">{title}</p> : null}
+          <div className={cn(title ? 'mt-1 text-sm leading-relaxed text-on-surface-variant' : 'text-sm leading-relaxed text-on-surface-variant')}>
+            {children}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front-end/src/shared/ui/Button.test.tsx
+++ b/front-end/src/shared/ui/Button.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import Button from './Button';
+import { renderWithProviders } from '../../test/utils/renderWithProviders';
+
+describe('Button', () => {
+  it('renderiza o rotulo e dispara clique', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+
+    const { getByRole } = renderWithProviders(
+      <Button onClick={onClick}>Salvar</Button>,
+    );
+
+    const button = getByRole('button', { name: 'Salvar' });
+    await user.click(button);
+
+    expect(button).toBeInTheDocument();
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/front-end/src/shared/ui/Button.tsx
+++ b/front-end/src/shared/ui/Button.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { cn } from '../../lib/utils';
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary' | 'ghost' | 'danger';
+}
+
+const variantClasses: Record<NonNullable<ButtonProps['variant']>, string> = {
+  primary: 'bg-primary text-on-primary shadow-[0_16px_26px_rgba(82,102,0,0.18)] hover:brightness-105',
+  secondary: 'bg-surface-container text-on-surface border border-outline-variant hover:bg-surface-container-high',
+  ghost: 'bg-transparent text-on-surface hover:bg-surface-container',
+  danger: 'bg-error text-on-error hover:brightness-105',
+};
+
+export default function Button({
+  type = 'button',
+  variant = 'primary',
+  className,
+  children,
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      type={type}
+      className={cn(
+        'inline-flex items-center justify-center gap-2 rounded-2xl px-5 py-3 text-sm font-bold transition-all disabled:cursor-not-allowed disabled:opacity-60',
+        variantClasses[variant],
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}

--- a/front-end/src/shared/ui/EmptyState.test.tsx
+++ b/front-end/src/shared/ui/EmptyState.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import EmptyState from './EmptyState';
+
+describe('EmptyState', () => {
+  it('renderiza título e descrição', () => {
+    const { getByText } = render(
+      <EmptyState title="Sem dados" description="Nenhum registro encontrado." />,
+    );
+
+    expect(getByText('Sem dados')).toBeInTheDocument();
+    expect(getByText('Nenhum registro encontrado.')).toBeInTheDocument();
+  });
+});

--- a/front-end/src/shared/ui/EmptyState.tsx
+++ b/front-end/src/shared/ui/EmptyState.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Inbox } from 'lucide-react';
+import { cn } from '../../lib/utils';
+
+interface EmptyStateProps {
+  title: string;
+  description?: string;
+  icon?: React.ElementType;
+  className?: string;
+}
+
+export default function EmptyState({
+  title,
+  description,
+  icon: Icon = Inbox,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div className={cn('rounded-[2rem] border border-outline-variant bg-surface-container-lowest px-6 py-10 text-center', className)}>
+      <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-surface-container text-on-surface-variant">
+        <Icon className="h-6 w-6" />
+      </div>
+      <h3 className="mt-4 text-lg font-bold text-on-surface">{title}</h3>
+      {description ? <p className="mt-2 text-sm leading-relaxed text-on-surface-variant">{description}</p> : null}
+    </div>
+  );
+}

--- a/front-end/src/shared/ui/Input.tsx
+++ b/front-end/src/shared/ui/Input.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { cn } from '../../lib/utils';
+
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  containerClassName?: string;
+  error?: string;
+  hint?: string;
+}
+
+export default function Input({ label, containerClassName, className, id, error, hint, ...props }: InputProps) {
+  return (
+    <div className={cn('space-y-2', containerClassName)}>
+      {label ? (
+        <label htmlFor={id} className="block pl-1 text-xs font-medium uppercase tracking-[0.18em] text-on-surface">
+          {label}
+        </label>
+      ) : null}
+      <input
+        id={id}
+        className={cn(
+          'w-full rounded-2xl bg-surface px-4 py-3.5 text-on-surface outline-none ring-1 transition-all placeholder:text-on-surface-variant/65 focus:ring-2 focus:ring-primary/20',
+          error ? 'ring-error/35 focus:ring-error/20' : 'ring-primary/5',
+          className,
+        )}
+        aria-invalid={Boolean(error)}
+        {...props}
+      />
+      {error ? <p className="pl-1 text-xs font-medium text-error">{error}</p> : null}
+      {!error && hint ? <p className="pl-1 text-xs text-on-surface-variant">{hint}</p> : null}
+    </div>
+  );
+}

--- a/front-end/src/shared/ui/KpiCard.tsx
+++ b/front-end/src/shared/ui/KpiCard.tsx
@@ -1,0 +1,3 @@
+export { default } from '../../components/KpiCard';
+export { resolveKpiIcon, resolveKpiTone } from '../../components/KpiCard';
+export type { KpiTone } from '../../components/KpiCard';

--- a/front-end/src/shared/ui/Modal.tsx
+++ b/front-end/src/shared/ui/Modal.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../components/Modal';

--- a/front-end/src/shared/ui/PageHeader.test.tsx
+++ b/front-end/src/shared/ui/PageHeader.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import PageHeader from './PageHeader';
+
+describe('PageHeader', () => {
+  it('renderiza título, descrição e ações', () => {
+    const { getByText } = render(
+      <PageHeader
+        title="Contas a pagar"
+        description="Controle financeiro"
+        actions={<button type="button">Nova conta</button>}
+      />,
+    );
+
+    expect(getByText('Contas a pagar')).toBeInTheDocument();
+    expect(getByText('Controle financeiro')).toBeInTheDocument();
+    expect(getByText('Nova conta')).toBeInTheDocument();
+  });
+});

--- a/front-end/src/shared/ui/PageHeader.tsx
+++ b/front-end/src/shared/ui/PageHeader.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { cn } from '../../lib/utils';
+
+interface PageHeaderProps {
+  title: string;
+  description?: string;
+  actions?: React.ReactNode;
+  className?: string;
+}
+
+export default function PageHeader({ title, description, actions, className }: PageHeaderProps) {
+  return (
+    <header className={cn('flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between', className)}>
+      <div>
+        <h1 className="text-3xl font-extrabold tracking-tight text-on-surface">{title}</h1>
+        {description ? <p className="mt-2 text-on-surface-variant">{description}</p> : null}
+      </div>
+      {actions ? <div className="flex items-center gap-3">{actions}</div> : null}
+    </header>
+  );
+}

--- a/front-end/src/shared/ui/Select.tsx
+++ b/front-end/src/shared/ui/Select.tsx
@@ -1,0 +1,2 @@
+export { default } from '../../components/CustomSelect';
+export type { CustomSelectOption } from '../../components/CustomSelect';

--- a/front-end/src/shared/ui/Skeleton.tsx
+++ b/front-end/src/shared/ui/Skeleton.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { cn } from '../../lib/utils';
+
+interface SkeletonProps {
+  className?: string;
+}
+
+export default function Skeleton({ className }: SkeletonProps) {
+  return <div className={cn('animate-pulse rounded-2xl bg-surface-container', className)} />;
+}

--- a/front-end/src/shared/ui/index.ts
+++ b/front-end/src/shared/ui/index.ts
@@ -1,0 +1,9 @@
+export { default as Alert } from './Alert';
+export { default as Button } from './Button';
+export { default as EmptyState } from './EmptyState';
+export { default as Input } from './Input';
+export { default as KpiCard } from './KpiCard';
+export { default as Modal } from './Modal';
+export { default as PageHeader } from './PageHeader';
+export { default as Select } from './Select';
+export { default as Skeleton } from './Skeleton';


### PR DESCRIPTION
Recupera a camada `shared/ui` sobre a branch corretiva de permissões, mantendo a ordem original da refatoração.

Escopo:
- componentes base reutilizáveis
- `Button`, `Input`, `Select`, `Modal`, `Alert`, `EmptyState`, `PageHeader`, `KpiCard`, `Skeleton`

Objetivo:
- reconstituir a stack correta para posterior merge na `main`.
