### PR TITLE
test(front): corrige testes da novalog para deploy

### DIFF
--- a/front-end/src/features/novalog/components/NovalogEntriesTable.test.tsx
+++ b/front-end/src/features/novalog/components/NovalogEntriesTable.test.tsx
@@ -7,7 +7,6 @@ describe('NovalogEntriesTable', () => {
   it('renderiza os lancamentos e dispara as acoes principais', async () => {
     const user = userEvent.setup();
     const onEdit = vi.fn();
-    const onDuplicate = vi.fn();
     const onDelete = vi.fn();
 
     const entry = {
@@ -30,8 +29,15 @@ describe('NovalogEntriesTable', () => {
     render(
       <NovalogEntriesTable
         entries={[entry]}
+        searchTerm=""
+        originFilter=""
+        destinationFilter=""
+        filteredCount={1}
+        totalCount={1}
+        onSearchChange={() => undefined}
+        onOriginFilterChange={() => undefined}
+        onDestinationFilterChange={() => undefined}
         onEdit={onEdit}
-        onDuplicate={onDuplicate}
         onDelete={onDelete}
       />,
     );
@@ -40,11 +46,9 @@ describe('NovalogEntriesTable', () => {
     expect(screen.getAllByText('Minerbrasil').length).toBeGreaterThan(0);
 
     await user.click(screen.getAllByRole('button', { name: 'Editar #1' })[0]);
-    await user.click(screen.getAllByRole('button', { name: 'Duplicar #1' })[0]);
     await user.click(screen.getAllByRole('button', { name: 'Excluir #1' })[0]);
 
     expect(onEdit).toHaveBeenCalledWith(entry);
-    expect(onDuplicate).toHaveBeenCalledWith(entry);
     expect(onDelete).toHaveBeenCalledWith(entry);
   });
 });

--- a/front-end/src/features/novalog/components/NovalogStandardEntryModal.test.tsx
+++ b/front-end/src/features/novalog/components/NovalogStandardEntryModal.test.tsx
@@ -33,7 +33,7 @@ describe('NovalogStandardEntryModal', () => {
     );
 
     expect(screen.getByText('Editar lancamento Novalog')).toBeInTheDocument();
-    expect(screen.getByText('Identificador 245')).toBeInTheDocument();
+    expect(screen.queryByText(/Identificador/i)).not.toBeInTheDocument();
     expect(screen.getByDisplayValue('770')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Salvar alteracoes' })).toBeInTheDocument();
   });


### PR DESCRIPTION
Corrige os testes de frontend da Novalog que estavam bloqueando o workflow `Deploy Production` após a entrada do módulo em `main`.

Ajustes incluídos:
- remove expectativa da ação de duplicar na tabela
- atualiza props obrigatórias do componente de tabela nos testes
- alinha o teste do modal padrão ao comportamento visual atual

Validação:
- `npm run test:front:run -- Novalog`