### PR TITLE
fix(novalog): compatibiliza colunas opcionais em producao

### DIFF
--- a/back-end/migrations/1713387600000_novalog_optional_columns_compat.sql
+++ b/back-end/migrations/1713387600000_novalog_optional_columns_compat.sql
@@ -1,0 +1,12 @@
+-- Up Migration
+
+alter table if exists novalog_operation_entries alter column ticket_number drop not null;
+alter table if exists novalog_operation_entries alter column fuel_station_name drop not null;
+alter table if exists novalog_operation_entries alter column driver_name drop not null;
+alter table if exists novalog_operation_entries alter column vehicle_label drop not null;
+alter table if exists novalog_operation_entries alter column notes drop not null;
+alter table if exists novalog_operation_entries alter column batch_key drop not null;
+alter table if exists novalog_operation_entries alter column created_by_user_id drop not null;
+alter table if exists novalog_operation_entries alter column updated_by_user_id drop not null;
+
+-- Down Migration

--- a/back-end/schema.sql
+++ b/back-end/schema.sql
@@ -705,6 +705,14 @@ from numbered
 where p.id = numbered.id;
 
 alter table if exists novalog_operation_entries drop column if exists code;
+alter table if exists novalog_operation_entries alter column ticket_number drop not null;
+alter table if exists novalog_operation_entries alter column fuel_station_name drop not null;
+alter table if exists novalog_operation_entries alter column driver_name drop not null;
+alter table if exists novalog_operation_entries alter column vehicle_label drop not null;
+alter table if exists novalog_operation_entries alter column notes drop not null;
+alter table if exists novalog_operation_entries alter column batch_key drop not null;
+alter table if exists novalog_operation_entries alter column created_by_user_id drop not null;
+alter table if exists novalog_operation_entries alter column updated_by_user_id drop not null;
 
 drop trigger if exists trg_tenants_display_id on tenants;
 create trigger trg_tenants_display_id

--- a/back-end/shared/http/error-handler.ts
+++ b/back-end/shared/http/error-handler.ts
@@ -23,6 +23,28 @@ export function errorHandler(
     return;
   }
 
+  if (error.code === '23502') {
+    sendErrorResponse(
+      res,
+      new AppError('Um campo obrigatorio do banco nao estava alinhado com o payload enviado.', {
+        statusCode: 400,
+        code: 'database_not_null_violation',
+      })
+    );
+    return;
+  }
+
+  if (error.code === '23503') {
+    sendErrorResponse(
+      res,
+      new AppError('O lancamento depende de um registro relacionado que nao foi encontrado no banco.', {
+        statusCode: 409,
+        code: 'database_foreign_key_violation',
+      })
+    );
+    return;
+  }
+
   if (error instanceof AppError) {
     sendErrorResponse(res, error);
     return;


### PR DESCRIPTION
## Resumo
- adiciona migration defensiva para remover `NOT NULL` de colunas opcionais da `novalog_operation_entries`
- alinha o `schema.sql` com essa compatibilidade
- melhora o tratamento de erros `23502` e `23503` para evitar `500` opaco

## Contexto
A criacao de lancamentos Novalog em producao estava retornando `500`. A suspeita principal aqui e incompatibilidade de constraints antigas na tabela em producao com o payload atual da feature.

## Validacao
- `npm test`